### PR TITLE
Show "create new course" only to privileged users

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -4,7 +4,7 @@
 <p id="notice"><%= notice %></p>
 <div class="pull-right">
   <div class="btn-group btn-group-sm" role="group" aria-label="...">
-    <%= link_to 'new course', new_course_path, class: "btn btn-default" %>
+    <%= link_to 'new course', new_course_path, class: "btn btn-default" if can? current_user, :manage, course %>
   </div>
 </div>
 <h1>Angebotene Kurse</h1>


### PR DESCRIPTION
The button to create a new course should not be shown to users who can't perform this action, just like the other buttons (for each course) aren't.